### PR TITLE
Resavanje segfaulta, razdvoji_kuglu_od_ivice() i README apdejt

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,18 @@ kugle imaju masu koja im se moze razlikovati ali su poluprecnici kugli isti, sud
 ![sketch-1631383043564](https://user-images.githubusercontent.com/70685786/133665943-e394c126-a5ca-4fea-a067-c93ed6304a16.png)
 ![kugla_teme_ivice](https://user-images.githubusercontent.com/70685786/134636621-f552fb91-865a-4570-a868-4cd222e08af2.png)
 
-## LINUX
-install sfml and g++
+## Linux
 
-git clone repository:
 ```
+pacman -S sfml
 git clone https://github.com/vmisovic/bilijar/
+cd bilijar/
+g++ -std=c++14 -O2 -o bilijar.out bilijar/*.cpp -lsfml-graphics -lsfml-window -lsfml-system
+./bilijar.out
 ```
-change directory:
+
+## Windows
+
 ```
-cd bilijar/bilijar/
-```
-compile:
-```
-g++ -std=c++14 -g -O2 -Wall -o program.out *.cpp -I SFML-2.5.1\include -L SFML-2.5.1\lib -lsfml-graphics -lsfml-window -lsfml-system
-```
-run:
-```
-./program.out
+g++ -std=c++14 -O2 -o bilijar.exe bilijar\*.cpp -I sfml\include -L sfml\lib -lsfml-graphics -lsfml-window -lsfml-system
 ```

--- a/bilijar/Source.cpp
+++ b/bilijar/Source.cpp
@@ -123,7 +123,7 @@ void crtaj_sto(sf::RenderWindow* prozor)
             k[i].crtaj();
 
     //isctravanje stapa u koliko su se kugle zaustavile
-    if (krecu_se == 0)
+    if (!krecu_se)
         k[0].crtaj_stap(mis, (float)tockic);
 }
 
@@ -210,9 +210,9 @@ int main()
             for (int i = 0; i < br_kugli; i++)
             {
                 bool udar_o_teme = 0;
-                for (int j = 0; j < br_tacaka || udar_o_teme == 1; j++)
-                    udar_o_teme = k[i].sudar_o_teme(tacke[j]) == 1;//u koliko kugla nije udarila u neko od temena
-                if (udar_o_teme == 0)
+                for (int j = 0; j < br_tacaka || udar_o_teme; j++)
+                    udar_o_teme = k[i].sudar_o_teme(tacke[j]);//u koliko kugla nije udarila u neko od temena
+                if (!udar_o_teme)
                     for (int l = 0; l < br_ivica; l++)
                         k[i].sudar_o_ivicu(ivice[l]);//proveri da li je udarila u neki od zidova
             }
@@ -220,16 +220,16 @@ int main()
             //deo za ponovno ispitivanje da li je sistem u mirovanju
             krecu_se = 0;
             for (int i = 0; i < br_kugli; i++)
-                if (k[i].krece_se() == 1)
+                if (k[i].krece_se())
                     krecu_se = 1;
 
-	        // razdvajanje kugli ako su slucajno ostale slepljene
-	        for (int i = 0; i < br_kugli - 1; i++)
-		        for (int j = i + 1; j < br_kugli; j++)
-		            k[i].razdvoji_kugle(&k[j]);
+	    // razdvajanje kugli ako su slucajno ostale slepljene
+	    for (int i = 0; i < br_kugli - 1; i++)
+		    for (int j = i + 1; j < br_kugli; j++)
+		        k[i].razdvoji_kugle(&k[j]);
         }
 
-        if(brojacfrejma%10==0)
+        if(!brojacfrejma%10)
         {
             brojacfrejma = 0;
             //brisanje prethodnog frejma

--- a/bilijar/Source.cpp
+++ b/bilijar/Source.cpp
@@ -223,10 +223,13 @@ int main()
                 if (k[i].krece_se())
                     krecu_se = 1;
 
-	    // razdvajanje kugli ako su slucajno ostale slepljene
 	    for (int i = 0; i < br_kugli - 1; i++)
-		    for (int j = i + 1; j < br_kugli; j++)
-		        k[i].razdvoji_kugle(&k[j]);
+	    {
+		    // razdvajanje kugli ako su slucajno ostale slepljene
+		    for (int j = i + 1; j < br_kugli; j++) k[i].razdvoji_kugle(&k[j]);
+		    // razdvajanje kugli od ivica
+		    for (int j = i + 1; j < br_ivica; j++) k[i].razdvoji_kuglu_od_ivice(ivice[j]);
+	    }
         }
 
         if(!brojacfrejma%10)

--- a/bilijar/kugla.cpp
+++ b/bilijar/kugla.cpp
@@ -76,20 +76,6 @@ bool kugla::sudar_kugli(kugla* druga)//dodeljuje nove vektore brzine kuglama u k
 int greska_poluprecnik=2;
 float greska_ugao=0.05;
 
-bool kugla::sudar_o_ivicu(ivica ivica1)//dodeljuje novi vektor brzine kugli u koliko je doslo do udara o ivicu
-{
-	if (ivica1.razdaljina_od(pozicija) >= (poluprecnik + greska_poluprecnik) ||
-		cos_uglaIzmedjuVektora(ivica1.pravac, pozicija - ivica1.tacka1) <= (0+greska_ugao) ||
-		cos_uglaIzmedjuVektora(pozicija - ivica1.tacka2, -ivica1.pravac) <= (0+greska_ugao))//provera sudara
-		return 0;
-	sf::Vector2f normalna, paralelna;
-	float cos_u1 = cos_uglaIzmedjuVektora(brzina, ivica1.pravac);
-	paralelna =  ivica1.pravac * (intenzitet(brzina) * cos_u1 / intenzitet(ivica1.pravac));
-	normalna = brzina - paralelna;
-	brzina = paralelna - normalna;
-	return 1;
-}
-
 bool kugla::sudar_o_teme(sf::Vector2f tacka)//dodeljuje novi vektor brzine kugli u koliko je doslo do udara o teme
 {
 	sf::Vector2f d = pozicija - tacka, normalna, paralelna;
@@ -100,6 +86,35 @@ bool kugla::sudar_o_teme(sf::Vector2f tacka)//dodeljuje novi vektor brzine kugli
 	paralelna = brzina - normalna;
 	brzina = paralelna - normalna;
 	return 1;
+}
+
+bool kugla::provera_sudara_ivica(ivica ivica1)
+{
+	if (ivica1.razdaljina_od(pozicija) >= (poluprecnik + greska_poluprecnik) ||
+		cos_uglaIzmedjuVektora(ivica1.pravac, pozicija - ivica1.tacka1) <= (0+greska_ugao) ||
+		cos_uglaIzmedjuVektora(pozicija - ivica1.tacka2, -ivica1.pravac) <= (0+greska_ugao))//provera sudara
+		return 0;
+	return 1;
+}
+
+bool kugla::sudar_o_ivicu(ivica ivica1)//dodeljuje novi vektor brzine kugli u koliko je doslo do udara o ivicu
+{
+	if(!provera_sudara_ivica(ivica1)) return 0;
+	sf::Vector2f normalna, paralelna;
+	float cos_u1 = cos_uglaIzmedjuVektora(brzina, ivica1.pravac);
+	paralelna =  ivica1.pravac * (intenzitet(brzina) * cos_u1 / intenzitet(ivica1.pravac));
+	normalna = brzina - paralelna;
+	brzina = paralelna - normalna;
+	return 1;
+}
+
+void kugla::razdvoji_kuglu_od_ivice(ivica ivica1)
+{
+    // kada sve kugle budu bile na stolu, promeniti ovu funkciju tako da ne stavlja kugle van stola
+    if(!krece_se()&&provera_sudara_ivica(ivica1))
+    {
+	pozicija=sf::Vector2f(pozicija.x+4,pozicija.y+4);
+    }
 }
 
 bool kugla::krece_se()//vraca vrednost 1 ako se kugla krece, u suprotnom 0

--- a/bilijar/kugla.h
+++ b/bilijar/kugla.h
@@ -64,6 +64,8 @@ public:
 	void razdvoji_kugle(kugla *druga);
 	bool sudar_o_ivicu(ivica ivica1);
 	bool sudar_o_teme(sf::Vector2f tacka);
+	bool provera_sudara_ivica(ivica ivica1);
+	void razdvoji_kuglu_od_ivice(ivica ivica1);
 
 	//funkcije za iscrtavanje
 	void crtaj();


### PR DESCRIPTION
Funkcija koja razdvaja kuglu od ivice ima samo najosnovniju funkcionalnost. Nakon dodavanja da sve kugle ostaju na stolu potrebno je u funkciji razdvojiti na slucajeve kako treba pomeriti kuglu u zavisnosti od ivice tako da kugla ostane na stolu.

README bi trebao biti doradjen sa uputsvima za skidanje SFML-a za windows i potrebno je naglasiti da je za verziju SFML-a 2.5.1 koja se trenutno koristi potrebno koristiti odredjeni kompajler koji se moze naci na stranici https://www.sfml-dev.org/download/sfml/2.5.1/. Ovaj kompajler koristiti samo ako sa kompajlerom koji korisnik vec ima dolazi do problema prilikom kompajlovanja.
Takodje bi umesto slike gde su prikazani uglovi trebalo da stoji slika kako igra izgleda (nakon postavljanja svih kugli na sto na pocetku igre).